### PR TITLE
Install a git pre-push lint hook as part of setup-test-tools.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -5,6 +5,24 @@ echo "# Install testing tools."
 echo "# Only works with Ubuntu / APT."
 echo "# --------------------------------------"
 
+hookScriptName=".git/hooks/pre-push"
+
+if [ -t 1 ]; then
+    echo "Install a git pre-push hook?"
+    select yn in "Yes" "No"; do
+        case $yn in
+            Yes)
+                echo "./lint.sh -f" >>$hookScriptName
+                echo "pre-push hook installed"
+                break
+                ;;
+            No)
+                break
+                ;;
+        esac
+    done
+fi
+
 if [[ -z "$ZIGPATH" ]]; then
     # If ZIGPATH is not set, set it to $pwd/.zig
     # In Docker environment this should by default be set to /opt/zig


### PR DESCRIPTION
See issue #1306. 

When running `./setup-dev.sh`, it is helpful to prompt the user if they want to install a git pre-push hook that automatically runs linting for them. The implementation uses a bash select to allow the user to choose whether to auto-format their code by linting (by typing the number 1 or 2). If the user selects yes. A pre-hook file will be created under .git/hook/ with a command `./lint.sh -f` to run the lint. 